### PR TITLE
Remove additional wrapper attribute in constructed GET-DATA DOs.

### DIFF
--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -775,8 +775,6 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 		// 65 - Cardholder Related Data
 		case (short) 0x0065:
-			buffer[offset++] = 0x65;
-			buffer[offset++] = 0x00;
 
 			// 5B - Name
 			buffer[offset++] = 0x5B;
@@ -797,17 +795,10 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 			buffer[offset++] = 0x01;
 			buffer[offset++] = sex;
 
-			// Set length for combined data
-			buffer[1] = (byte) (offset - 2);
-
 			return offset;
 
 		// 6E - Application Related Data
 		case (short) 0x006E:
-			buffer[offset++] = 0x6E;
-			// Total length assumed to be >= 128 and < 256
-			buffer[offset++] = (byte) 0x81;
-			buffer[offset++] = 0;
 
 			// 4F - AID
 			buffer[offset++] = 0x4F;
@@ -886,16 +877,10 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 			// Set length of combined discretionary data objects
 			buffer[ddoLengthOffset] = (byte) (offset - ddoLengthOffset - 1);
-
-			// Set length of combined data
-			buffer[2] = (byte) (offset - 3);
-
 			return offset;
 
 		// 7A - Security support template
 		case (short) 0x007A:
-			buffer[offset++] = 0x7A;
-			buffer[offset++] = (byte) 0x05;
 
 			// 93 - Digital signature counter
 			buffer[offset++] = (byte) 0x93;
@@ -907,20 +892,6 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 		// 7F21 - Cardholder Certificate
 		case (short) 0x7F21:
-			// Use buffer since certificate may be longer than
-			// RESPONSE_MAX_LENGTH
-			buffer[offset++] = 0x7F;
-			buffer[offset++] = 0x21;
-
-			if (cert_length < 128) {
-				buffer[offset++] = (byte) cert_length;
-			} else if (cert_length < 256) {
-				buffer[offset++] = (byte) 0x81;
-				buffer[offset++] = (byte) cert_length;
-			} else {
-				buffer[offset++] = (byte) 0x82;
-				offset = Util.setShort(buffer, offset, cert_length);
-			}
 
 			if (cert_length > 0) {
 				offset = Util.arrayCopyNonAtomic(cert, _0, buffer, offset,

--- a/test/test/openpgpcardTest/OpenPGPAppletTest.java
+++ b/test/test/openpgpcardTest/OpenPGPAppletTest.java
@@ -158,7 +158,7 @@ public class OpenPGPAppletTest {
 
 		simulator.reset();
 		simulator.selectApplet(aid);
-		byte[] expect = {0x7f, 0x21, 8, 1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0};
+		byte[] expect = {1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0};
 		resp = simulator.transmitCommand(new byte[] {0, (byte) 0xca, 0x7f, 0x21});
 		assertArrayEquals(expect, resp);
 	}
@@ -259,7 +259,7 @@ public class OpenPGPAppletTest {
 		byte[] resp = simulator.transmitCommand(new byte[] {0, (byte) 0xca, 0, 0x6e});
 		byte[] code = Arrays.copyOfRange(resp, resp.length - 2, resp.length);
 		assertArrayEquals(success, code);
-		short offs = 4;
+		short offs = 1;
 		offs += resp[offs];
 		offs += 3;
 		offs += resp[offs];


### PR DESCRIPTION
Previously GET-DATA wrapped constructed DOs into an attribute with the
same tag as the DO. The OpenPGP Card 2.0 does not do this, so some
software might be confused. Note that GnuPG effectively ignores any
structure inside constructed DOs and is therefore not affected.
