### PR TITLE
WIP: RAM usage reduction

### DIFF
--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -1280,11 +1280,11 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 		// determine length of modulus tag
 		final short modLen = key.getModulusLength();
-		short modTagLen = (short)(1 + sizeLength(modLen) + modLen);
+		short modTagLen = (short)(1 + getLengthBytes(modLen) + modLen);
 
 		// determine length of exponent tag
 		final short expLen = key.getExponentLength();
-		short expTagLen = (short)(1 + sizeLength(expLen) + expLen);
+		short expTagLen = (short)(1 + getLengthBytes(expLen) + expLen);
 
 		// compute size of all child tags
 		final short tagsLen = (short)(modTagLen + expTagLen);
@@ -1309,31 +1309,6 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 		// done
 		return offset;
-	}
-
-	private short sizeLength(short length) {
-		if(length < 128) {
-			return 1;
-		} else if(length < 256) {
-			return 2;
-		} else {
-			return 3;
-		}
-	}
-
-	private short putLength(byte[] dst, short offset, short length) {
-		if(length < 128) {
-			dst[offset++] = (byte)length;
-			return 1;
-		} else if(length < 256) {
-			dst[offset++] = (byte)0x81;
-			dst[offset++] = (byte)length;
-			return 2;
-		} else {
-			buffer[offset++] = (byte)0x82;
-			Util.setShort(buffer, offset, length);
-			return 3;
-		}
 	}
 
 	/**
@@ -1475,6 +1450,29 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 		else
 			return 3;
 	}
+
+    /**
+     * Write a length to a buffer in TLV encoding.
+     *
+     * @param dst buffer to write to
+     * @param offset to write at
+     * @param length the length to be written
+     * @return length of encoded length element in buffer
+     */
+    private short putLength(byte[] dst, short offset, short length) {
+        if(length < 128) {
+            dst[offset++] = (byte)length;
+            return 1;
+        } else if(length < 256) {
+            dst[offset++] = (byte)0x81;
+            dst[offset++] = (byte)length;
+            return 2;
+        } else {
+            buffer[offset++] = (byte)0x82;
+            Util.setShort(buffer, offset, length);
+            return 3;
+        }
+    }
 
 	/**
 	 * Return the key of the type requested: - B6: Digital signatures - B8:

--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -687,13 +687,17 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 	private short internalAuthenticate(APDU apdu) {
 		if (!(pw1.isValidated() && pw1_modes[PW1_MODE_NO82]))
 			ISOException.throwIt(SW_SECURITY_STATUS_NOT_SATISFIED);
-		Util.arrayCopyNonAtomic(buffer, _0, tmp, _0, in_received);
-
 		if (!auth_key.getPrivate().isInitialized())
 			ISOException.throwIt(SW_CONDITIONS_NOT_SATISFIED);
 
+		// initialize cipher instance
 		cipher.init(auth_key.getPrivate(), Cipher.MODE_ENCRYPT);
-		return cipher.doFinal(tmp, _0, in_received, buffer, _0);
+		// perform the operation
+		short length = cipher.doFinal(buffer, _0, in_received, buffer, in_received);
+		// copy the result back to the start of buffer
+		Util.arrayCopyNonAtomic(buffer, in_received, buffer, _0, length);
+		// return length of result
+		return length;
 	}
 
 	/**

--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -132,8 +132,6 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 	private Cipher cipher;
 	private RandomData random;
 
-	private byte[] tmp;
-
 	private byte[] buffer;
 	private short out_left = 0;
 	private short out_sent = 0;
@@ -198,8 +196,6 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 
 	public OpenPGPApplet() {
 		// Create temporary arrays
-		tmp = JCSystem.makeTransientByteArray(BUFFER_MAX_LENGTH,
-				JCSystem.CLEAR_ON_DESELECT);
 		buffer = JCSystem.makeTransientByteArray(BUFFER_MAX_LENGTH,
 				JCSystem.CLEAR_ON_DESELECT);
 		pw1_modes = JCSystem.makeTransientBooleanArray((short) 2,


### PR DESCRIPTION
WORK IN PROGRESS! DO NOT MERGE YET!

The OpenPGP applet currently uses two large buffers, "tmp" and "buffer". The total RAM usage of the applet makes it impossible to install and use it on most common JavaCard models. More specifically only a few JCOP cards have enough memory to run the applet.

After some research I found that "tmp" can be eliminated entirely. This patch series is a work in progress to eliminate it entirely, which in itself is working on my branch.

The "tmp" buffer is used in four places:
- As a serialization buffer in sendPublicKey. This usage can be eliminated by using a better serialization algorithm that predicts memory size before starting to serialize.
- As an operational buffer in computeDigitalSignature, decipher and internalAuthenticate. This usage can be eliminated by recognizing that "buffer" is always large enough since the actual message size is always 256 for RSA-based operations with 2048bit keys. The current buffer would also be large enough for 4096bit operations, should they become supported.

My plan is to add additional size checks for added safety.
