### PR TITLE
Remove tmp buffer to cut down on transient memory needs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ ykneo-openpgp-*.tar.gz.sig
 test/.classpath
 test/.project
 test/lib/jcardsim-2.2.2-all.jar
+test/lib/hamcrest-all-1.3.jar
 jacoco.exec
 jacoco.xml
 jacoco/
@@ -21,3 +22,4 @@ test/lib/jacoco.jar
 test/lib/jacocoagent.jar
 test/lib/jacocoant.jar
 test/lib/jacocoreport.jar
+.DS_Store


### PR DESCRIPTION
This pull request removes the need for the ```tmp``` buffer, so that the applet can fit on more constrained Java Cards. The ```tmp``` buffer was used in two places, basically: 

1. In security operations, the input data was copied to ```tmp```, where it was passed to ```cipher.doFinal``` as the source; ```buffer``` was passed as the destination. The [docs on Cipher.doFinal](http://www.win.tue.nl/pinpasjc/docs/apis/jc222/javacardx/crypto/Cipher.html#doFinal(byte%5B%5D,%20short,%20short,%20byte%5B%5D,%20short)) indicate that the source and destination buffers can be the same, provided that the output bytes do not overlap with the input bytes. Since all of our inputs are ≤256 bytes, and all of our outputs are 256 bytes, there's plenty of room to place the output in ```buffer``` after the input, and subsequently copy it to the beginning of ```buffer```. 
2. When building public key data for output, the data was built up in ```tmp``` and then copied to ```buffer```. This change simply replaces all the places where we had ```tmp``` with ```buffer```, after prepending the tag and length. Previously, tmp was used so that we could determine whether to output a two-byte or three-byte length tag at the beginning of ```buffer```. But since the applet only supports 2048-bit keys, we know that the length of the wrapper DO will always be greater than 256; for a 2048-bit key, we have a 256 byte modulus + 3 byte exponent + tlv encoding overhead. Thus there's no need to guess at the length of this data object. 

I've tested this and confirmed that all functions work the same on a Yubikey NEO running the stock applet, and a J3A040 smart card running this code. 