### PR TITLE
Support for private use data objects

### DIFF
--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -93,6 +93,8 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 	private static final byte[] PW3_DEFAULT = { 0x31, 0x32, 0x33, 0x34, 0x35,
 			0x36, 0x37, 0x38 };
 
+	private static final short SW_REFERENCED_DATA_NOT_FOUND = 0x6A88;
+
 	private byte[] loginData;
 	private short loginData_length;
 
@@ -651,7 +653,7 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 			pw1_modes[PW1_MODE_NO81] = false;
 
 		if (!sig_key.getPrivate().isInitialized())
-			ISOException.throwIt(SW_CONDITIONS_NOT_SATISFIED);
+			ISOException.throwIt(SW_REFERENCED_DATA_NOT_FOUND);
 
 		cipher.init(sig_key.getPrivate(), Cipher.MODE_ENCRYPT);
 		increaseDSCounter();
@@ -676,7 +678,7 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 		if (!(pw1.isValidated() && pw1_modes[PW1_MODE_NO82]))
 			ISOException.throwIt(SW_SECURITY_STATUS_NOT_SATISFIED);
 		if (!dec_key.getPrivate().isInitialized())
-			ISOException.throwIt(SW_CONDITIONS_NOT_SATISFIED);
+			ISOException.throwIt(SW_REFERENCED_DATA_NOT_FOUND);
 
 		cipher.init(dec_key.getPrivate(), Cipher.MODE_DECRYPT);
 
@@ -700,7 +702,7 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 			ISOException.throwIt(SW_SECURITY_STATUS_NOT_SATISFIED);
 
 		if (!auth_key.getPrivate().isInitialized())
-			ISOException.throwIt(SW_CONDITIONS_NOT_SATISFIED);
+			ISOException.throwIt(SW_REFERENCED_DATA_NOT_FOUND);
 
 		cipher.init(auth_key.getPrivate(), Cipher.MODE_ENCRYPT);
 		short length = cipher.doFinal(buffer, _0, in_received, buffer, in_received);

--- a/test/test/openpgpcardTest/OpenPGPAppletTest.java
+++ b/test/test/openpgpcardTest/OpenPGPAppletTest.java
@@ -158,6 +158,96 @@ public class OpenPGPAppletTest {
 	}
 
 	@Test
+	public void testPrivateUseDo1() {
+		byte[] data = {0, (byte) 0xda, 0x01, 0x01, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+		byte[] resp = simulator.transmitCommand(data);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO1 fails with no PIN
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(data);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO1 fails with PW3
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(data);
+		assertArrayEquals(success, resp); // PUT DO1 succeeds with PW1 / Mode 82
+
+		simulator.reset();
+		simulator.selectApplet(aid);
+		byte[] expect = {1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0x00};
+		resp = simulator.transmitCommand(new byte[] {0, (byte) 0xca, 0x01, 0x01});
+		assertArrayEquals(expect, resp);
+	}
+
+	@Test
+	public void testPrivateUseDo2() {
+		byte[] data = {0, (byte) 0xda, 0x01, 0x02, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+		byte[] resp = simulator.transmitCommand(data);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO2 fails with no PIN
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(data);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO2 fails with PW1 / Mode 82
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(data);
+		assertArrayEquals(success, resp); // PUT DO2 succeeds with PW3
+
+		simulator.reset();
+		simulator.selectApplet(aid);
+		byte[] expect = {1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0x00};
+		resp = simulator.transmitCommand(new byte[] {0, (byte) 0xca, 0x01, 0x02});
+		assertArrayEquals(expect, resp);
+	}
+
+	@Test
+	public void testPrivateUseDo3() {
+		byte[] putData = {0, (byte) 0xda, 0x01, 0x03, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+		byte[] resp = simulator.transmitCommand(putData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO3 fails with no PIN
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(putData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO3 fails with PW3
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(putData);
+		assertArrayEquals(success, resp); // PUT DO3 succeeds with PW1 / Mode 82
+
+		simulator.reset();
+		simulator.selectApplet(aid);
+		byte[] getData = {0, (byte) 0xca, 0x01, 0x03};
+		byte[] expect = {1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0x00};
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // GET DO3 fails with no PIN
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // GET DO3 fails with PW3
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(expect, resp); // GET DO3 succeeds with PW1 / Mode 82
+	}
+
+	@Test
+	public void testPrivateUseDo4() {
+		byte[] putData = {0, (byte) 0xda, 0x01, 0x04, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+		byte[] resp = simulator.transmitCommand(putData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO4 fails with no PIN
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(putData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // PUT DO4 fails with PW1 / Mode 82
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(putData);
+		assertArrayEquals(success, resp); // PUT DO4 succeeds with PW3
+
+		simulator.reset();
+		simulator.selectApplet(aid);
+		byte[] getData = {0, (byte) 0xca, 0x01, 0x04};
+		byte[] expect = {1, 2, 3, 4, 5, 6, 7, 8, (byte) 0x90, 0x00};
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // GET DO4 fails with no PIN
+		assertEquals(true, doVerify("123456", (byte) 0x82));
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(new byte[] {0x69, (byte) 0x82}, resp); // GET DO4 fails with PW1 / Mode 82
+		assertEquals(true, doVerify("12345678", (byte) 0x83));
+		resp = simulator.transmitCommand(getData);
+		assertArrayEquals(expect, resp); // GET DO4 succeeds with PW3
+	}
+
+	@Test
 	public void testSignWithoutPin() {
 		assertEquals(true, doVerify("12345678", (byte) 0x83));
 		byte[] command = {0x00, 0x47, (byte) 0x80, 0x00, 0x01, (byte) 0xb6};


### PR DESCRIPTION
This pull request adds support for the four private use data objects defined in the OpenPGP smart card specification. These data objects can be set with the privatedo command in gpg's card-edit facility. While optional, they are useful for some workflows; in particular, data object 0103 can be used by TrueCrypt to store a passphrase for symmetric full disk encryption. 

I've added test coverage for each of the data objects, and you'll notice that the testPrivateUseDo4 case appears to fail. This apparent failure is due to [a known bug in jCardSim](https://github.com/licel/jcardsim/issues/67); the logic I've implemented in the applet is sound, and this test case succeeds when the applet is tested on a physical card. Once the jCardSim issue is addressed, the test case should succeed in the simulator as well. 

This pull request also contains, in a separate commit, a minor fix to an error status message. When a user attempts to perform a security operation with an uninitialized key, the official OpenPGP smart card returns a status of 6A88, "referenced data not found". This is more descriptive than the status that the applet currently returns (6985, "conditions not satisfied"). I'm working on improved error messages in OpenKeychain after [a user experienced this issue](https://github.com/open-keychain/open-keychain/issues/1301#issuecomment-105344592), and returning the correct error code in this case will allow the OpenKeychain UI to display the correct message. 

I am making this contribution under the terms of the GPL 2+ license.
