### PR TITLE
setIncomingAndReceive() should be called before data access

### DIFF
--- a/applet/src/openpgpcard/OpenPGPApplet.java
+++ b/applet/src/openpgpcard/OpenPGPApplet.java
@@ -444,6 +444,9 @@ public class OpenPGPApplet extends Applet implements ISO7816 {
 		short p1p2 = Util.makeShort(buf[OFFSET_P1], buf[OFFSET_P2]);
 		short len = (short) (buf[OFFSET_LC] & 0xFF);
 
+		if(len > (short) 0)
+			apdu.setIncomingAndReceive();
+
 		// Reset chaining if it was not yet initiated
 		if (!chain) {
 			resetChaining();


### PR DESCRIPTION
When I test this applet on J2A040 with T=0 protocol, I found invalid data in APDU buffer. By adding apdu.setIncomingAndReceive() call before data access on case 3/4 APDU, the problem was solved.